### PR TITLE
Update python_version 3.13 phase 1 and 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.2.0
+    rev: v4.1.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
@@ -27,7 +27,7 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.13
+    rev: v0.11.7
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Tenable.sc
 
-Publisher: Splunk \
-Connector Version: 2.4.0 \
-Product Vendor: Tenable \
-Product Name: Tenable.sc \
+Publisher: Splunk <br>
+Connector Version: 2.4.0 <br>
+Product Vendor: Tenable <br>
+Product Name: Tenable.sc <br>
 Minimum Product Version: 6.3.0
 
 This app integrates with Tenable's SecurityCenter to provide endpoint-based investigative actions
@@ -33,22 +33,22 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity \
-[scan endpoint](#action-scan-endpoint) - Runs a scan against a specified IP or host \
-[list vulnerabilities](#action-list-vulnerabilities) - Query Tenable.sc for a list of vulnerabilities associated with an IP or host name or CVEID \
-[list policies](#action-list-policies) - Lists the scan policies available in Tenable.sc \
-[list repositories](#action-list-repositories) - Lists the repositories available in Tenable.sc \
-[update asset](#action-update-asset) - Update existing asset with provided fields or create a new one as a 'static' type \
-[update group](#action-update-group) - Update existing group with provided fields \
-[list credentials](#action-list-credentials) - Lists the credentials available in Tenable.sc \
-[list scans](#action-list-scans) - Lists the scan results in Tenable.sc \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity <br>
+[scan endpoint](#action-scan-endpoint) - Runs a scan against a specified IP or host <br>
+[list vulnerabilities](#action-list-vulnerabilities) - Query Tenable.sc for a list of vulnerabilities associated with an IP or host name or CVEID <br>
+[list policies](#action-list-policies) - Lists the scan policies available in Tenable.sc <br>
+[list repositories](#action-list-repositories) - Lists the repositories available in Tenable.sc <br>
+[update asset](#action-update-asset) - Update existing asset with provided fields or create a new one as a 'static' type <br>
+[update group](#action-update-group) - Update existing group with provided fields <br>
+[list credentials](#action-list-credentials) - Lists the credentials available in Tenable.sc <br>
+[list scans](#action-list-scans) - Lists the scan results in Tenable.sc <br>
 [scan information](#action-scan-information) - Gets the information of a scan in Tenable.sc
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -63,7 +63,7 @@ No Output
 
 Runs a scan against a specified IP or host
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -186,7 +186,7 @@ action_result.parameter.report_source | string | | |
 
 Query Tenable.sc for a list of vulnerabilities associated with an IP or host name or CVEID
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 If the input IP / host name / CVEID is not available in the server, Action will pass with 0 vulnerability.
@@ -236,7 +236,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Lists the scan policies available in Tenable.sc
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -266,7 +266,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Lists the repositories available in Tenable.sc
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -295,7 +295,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Update existing asset with provided fields or create a new one as a 'static' type
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 View Tenable.sc API docs for available fields to update.
@@ -379,7 +379,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Update existing group with provided fields
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 View Tenable.sc API docs for available fields to update.
@@ -424,7 +424,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Lists the credentials available in Tenable.sc
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 This action result does not contain any sensitive information like password.
@@ -452,7 +452,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Lists the scan results in Tenable.sc
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 This action result does not contain any sensitive information like password.
@@ -487,7 +487,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Gets the information of a scan in Tenable.sc
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 This action result does not contain any sensitive information like password.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 * Remove beautifulsoup4 from requirements.txt
+* Update Python version for 3.13

--- a/tenablesc.json
+++ b/tenablesc.json
@@ -16,7 +16,7 @@
     "product_name": "Tenable.sc",
     "product_version_regex": ".*",
     "min_phantom_version": "6.3.0",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "logo": "logo_tenablesc.svg",
     "logo_dark": "logo_tenablesc_dark.svg",

--- a/tenablesc.json
+++ b/tenablesc.json
@@ -2294,5 +2294,11 @@
             ],
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase1and2)